### PR TITLE
correct german translation

### DIFF
--- a/l10n/DEU/console.ini
+++ b/l10n/DEU/console.ini
@@ -216,7 +216,7 @@
 "Split &Horizontally"="Horizontal splitten"
 "Split &Vertically"="Vertikal splitten"
 "Stop Scr&olling"="Scroll-stop"
-"Swap Views"="Anzeige auswächseln"
+"Swap Views"="Anzeige auswechseln"
 "Switch On/Off Transparency"="Transparaent An/Aus"
 "Ta&bs"="Tabs"
 "Tab"="Tab"


### PR DESCRIPTION
German GUI Typo "Editieren -> Anzeige auswächseln" should be "Editieren -> Anzeige auswechseln"
